### PR TITLE
Fix mobile card readability

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,87 +105,87 @@
 </div>
 <ul class="list-none ml-0 pl-0 grid grid-cols-1 md:grid-cols-2 gap-6">
             <!-- Card 1: Info -->
-            <li tabindex="0" role="button" aria-expanded="false" aria-controls="about-blurb-1" onclick="toggleBlurb('about-blurb-1', this)" onkeydown="if(event.key==='Enter'||event.key===' '){toggleBlurb('about-blurb-1', this)}" class="relative bg- transition-transform duration-200 hover:scale-105 active:scale-95 focus:outline-none focus-visible:ring-4 focus-visible:ring-teal-400 focus-visible:ring-offset-2blue-50 border-l-4 border-blue-400 rounded-lg shadow px-6 py-4 mb-0 flex items-start gap-4 cursor-pointer focus:outline-none focus:ring-2 focus:ring-blue-400 hover:scale-[1.03] hover:shadow-2xl transition-all group">
+            <li tabindex="0" role="button" aria-expanded="false" aria-controls="about-blurb-1" onclick="toggleBlurb('about-blurb-1', this)" onkeydown="if(event.key==='Enter'||event.key===' '){toggleBlurb('about-blurb-1', this)}" class="relative bg-blue-50 dark:bg-gray-700  transition-transform duration-200 hover:scale-105 active:scale-95 focus:outline-none focus-visible:ring-4 focus-visible:ring-teal-400 focus-visible:ring-offset-2 border-l-4 border-blue-400 rounded-lg shadow px-6 py-4 mb-0 flex items-start gap-4 cursor-pointer focus:outline-none focus:ring-2 focus:ring-blue-400 hover:scale-[1.03] hover:shadow-2xl transition-all group">
               <span class="flex-shrink-0 mt-1 text-blue-500">
                 <!-- Info Icon -->
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-7 w-7" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M12 2a10 10 0 100 20 10 10 0 000-20z"/></svg>
               </span>
               <div class="flex-1">
-                <span class="font-semibold text-blue-900">What vector search is and why it matters</span>
+                <span class="font-semibold text-blue-900 dark:text-white">What vector search is and why it matters</span>
                 <span class="ml-auto flex items-center justify-center">
                   <svg class="chevron h-7 w-7 text-blue-400 transition-transform duration-300 group-aria-expanded:rotate-180" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
                 </span>
-                <span id="about-blurb-1" class="block italic text-blue-700 text-base mt-3 hidden">Understand the fundamental concepts behind vector search and why it’s revolutionizing how we build search systems.</span>
+                <span id="about-blurb-1" class="block italic text-blue-700 dark:text-gray-200 text-base mt-3 hidden">Understand the fundamental concepts behind vector search and why it’s revolutionizing how we build search systems.</span>
               </div>
             </li>
             <!-- Card 2: Chip -->
-            <li tabindex="0" role="button" aria-expanded="false" aria-controls="about-blurb-2" onclick="toggleBlurb('about-blurb-2', this)" onkeydown="if(event.key==='Enter'||event.key===' '){toggleBlurb('about-blurb-2', this)}" class="relative bg- transition-transform duration-200 hover:scale-105 active:scale-95 focus:outline-none focus-visible:ring-4 focus-visible:ring-teal-400 focus-visible:ring-offset-2teal-50 border-l-4 border-teal-400 rounded-lg shadow px-6 py-4 mb-0 flex items-start gap-4 cursor-pointer focus:outline-none focus:ring-2 focus:ring-teal-400 hover:scale-[1.03] hover:shadow-2xl transition-all group">
+            <li tabindex="0" role="button" aria-expanded="false" aria-controls="about-blurb-2" onclick="toggleBlurb('about-blurb-2', this)" onkeydown="if(event.key==='Enter'||event.key===' '){toggleBlurb('about-blurb-2', this)}" class="relative bg-teal-50 dark:bg-gray-700  transition-transform duration-200 hover:scale-105 active:scale-95 focus:outline-none focus-visible:ring-4 focus-visible:ring-teal-400 focus-visible:ring-offset-2 border-l-4 border-teal-400 rounded-lg shadow px-6 py-4 mb-0 flex items-start gap-4 cursor-pointer focus:outline-none focus:ring-2 focus:ring-teal-400 hover:scale-[1.03] hover:shadow-2xl transition-all group">
               <span class="flex-shrink-0 mt-1 text-teal-500">
                 <!-- Chip Icon -->
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-7 w-7" fill="none" viewBox="0 0 24 24" stroke="currentColor"><rect x="4" y="4" width="16" height="16" rx="4"/><path d="M9 9h6v6H9z"/></svg>
               </span>
               <div class="flex-1">
-                <span class="font-semibold text-blue-900">Generating and using vector embeddings</span>
+                <span class="font-semibold text-blue-900 dark:text-white">Generating and using vector embeddings</span>
                 <span class="ml-auto flex items-center justify-center">
                   <svg class="chevron h-7 w-7 text-teal-400 transition-transform duration-300 group-aria-expanded:rotate-180" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
                 </span>
-                <span id="about-blurb-2" class="block italic text-blue-700 text-base mt-3 hidden">Learn practical techniques to create, store, and leverage embeddings for real-world data and applications.</span>
+                <span id="about-blurb-2" class="block italic text-blue-700 dark:text-gray-200 text-base mt-3 hidden">Learn practical techniques to create, store, and leverage embeddings for real-world data and applications.</span>
               </div>
             </li>
             <!-- Card 3: Server -->
-            <li tabindex="0" role="button" aria-expanded="false" aria-controls="about-blurb-3" onclick="toggleBlurb('about-blurb-3', this)" onkeydown="if(event.key==='Enter'||event.key===' '){toggleBlurb('about-blurb-3', this)}" class="relative bg- transition-transform duration-200 hover:scale-105 active:scale-95 focus:outline-none focus-visible:ring-4 focus-visible:ring-teal-400 focus-visible:ring-offset-2green-50 border-l-4 border-green-400 rounded-lg shadow px-6 py-4 mb-0 flex items-start gap-4 cursor-pointer focus:outline-none focus:ring-2 focus:ring-green-400 hover:scale-[1.03] hover:shadow-2xl transition-all group">
+            <li tabindex="0" role="button" aria-expanded="false" aria-controls="about-blurb-3" onclick="toggleBlurb('about-blurb-3', this)" onkeydown="if(event.key==='Enter'||event.key===' '){toggleBlurb('about-blurb-3', this)}" class="relative bg-green-50 dark:bg-gray-700  transition-transform duration-200 hover:scale-105 active:scale-95 focus:outline-none focus-visible:ring-4 focus-visible:ring-teal-400 focus-visible:ring-offset-2 border-l-4 border-green-400 rounded-lg shadow px-6 py-4 mb-0 flex items-start gap-4 cursor-pointer focus:outline-none focus:ring-2 focus:ring-green-400 hover:scale-[1.03] hover:shadow-2xl transition-all group">
               <span class="flex-shrink-0 mt-1 text-green-500">
                 <!-- Server Icon -->
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-7 w-7" fill="none" viewBox="0 0 24 24" stroke="currentColor"><rect x="3" y="7" width="18" height="10" rx="2"/><path d="M7 17v2m10-2v2"/></svg>
               </span>
               <div class="flex-1">
-                <span class="font-semibold text-blue-900">Building a vector search backend in Node.js</span>
+                <span class="font-semibold text-blue-900 dark:text-white">Building a vector search backend in Node.js</span>
                 <span class="ml-auto flex items-center justify-center">
                   <svg class="chevron h-7 w-7 text-green-400 transition-transform duration-300 group-aria-expanded:rotate-180" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
                 </span>
-                <span id="about-blurb-3" class="block italic text-blue-700 text-base mt-3 hidden">Step through building a performant, scalable backend using JavaScript and Node.js, with hands-on code examples.</span>
+                <span id="about-blurb-3" class="block italic text-blue-700 dark:text-gray-200 text-base mt-3 hidden">Step through building a performant, scalable backend using JavaScript and Node.js, with hands-on code examples.</span>
               </div>
             </li>
             <!-- Card 4: Globe -->
-            <li tabindex="0" role="button" aria-expanded="false" aria-controls="about-blurb-4" onclick="toggleBlurb('about-blurb-4', this)" onkeydown="if(event.key==='Enter'||event.key===' '){toggleBlurb('about-blurb-4', this)}" class="relative bg- transition-transform duration-200 hover:scale-105 active:scale-95 focus:outline-none focus-visible:ring-4 focus-visible:ring-teal-400 focus-visible:ring-offset-2purple-50 border-l-4 border-purple-400 rounded-lg shadow px-6 py-4 mb-0 flex items-start gap-4 cursor-pointer focus:outline-none focus:ring-2 focus:ring-purple-400 hover:scale-[1.03] hover:shadow-2xl transition-all group">
+            <li tabindex="0" role="button" aria-expanded="false" aria-controls="about-blurb-4" onclick="toggleBlurb('about-blurb-4', this)" onkeydown="if(event.key==='Enter'||event.key===' '){toggleBlurb('about-blurb-4', this)}" class="relative bg-purple-50 dark:bg-gray-700  transition-transform duration-200 hover:scale-105 active:scale-95 focus:outline-none focus-visible:ring-4 focus-visible:ring-teal-400 focus-visible:ring-offset-2 border-l-4 border-purple-400 rounded-lg shadow px-6 py-4 mb-0 flex items-start gap-4 cursor-pointer focus:outline-none focus:ring-2 focus:ring-purple-400 hover:scale-[1.03] hover:shadow-2xl transition-all group">
               <span class="flex-shrink-0 mt-1 text-purple-500">
                 <!-- Globe Icon -->
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-7 w-7" fill="none" viewBox="0 0 24 24" stroke="currentColor"><circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 010 20"/></svg>
               </span>
               <div class="flex-1">
-                <span class="font-semibold text-blue-900">Designing and optimizing search APIs</span>
+                <span class="font-semibold text-blue-900 dark:text-white">Designing and optimizing search APIs</span>
                 <span class="ml-auto flex items-center justify-center">
                   <svg class="chevron h-7 w-7 text-purple-400 transition-transform duration-300 group-aria-expanded:rotate-180" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
                 </span>
-                <span id="about-blurb-4" class="block italic text-blue-700 text-base mt-3 hidden">Discover best practices for API design, including how to expose powerful vector search features to your applications.</span>
+                <span id="about-blurb-4" class="block italic text-blue-700 dark:text-gray-200 text-base mt-3 hidden">Discover best practices for API design, including how to expose powerful vector search features to your applications.</span>
               </div>
             </li>
             <!-- Card 5: Adjustments -->
-            <li tabindex="0" role="button" aria-expanded="false" aria-controls="about-blurb-5" onclick="toggleBlurb('about-blurb-5', this)" onkeydown="if(event.key==='Enter'||event.key===' '){toggleBlurb('about-blurb-5', this)}" class="relative bg- transition-transform duration-200 hover:scale-105 active:scale-95 focus:outline-none focus-visible:ring-4 focus-visible:ring-teal-400 focus-visible:ring-offset-2yellow-50 border-l-4 border-yellow-400 rounded-lg shadow px-6 py-4 mb-0 flex items-start gap-4 cursor-pointer focus:outline-none focus:ring-2 focus:ring-yellow-400 hover:scale-[1.03] hover:shadow-2xl transition-all group">
+            <li tabindex="0" role="button" aria-expanded="false" aria-controls="about-blurb-5" onclick="toggleBlurb('about-blurb-5', this)" onkeydown="if(event.key==='Enter'||event.key===' '){toggleBlurb('about-blurb-5', this)}" class="relative bg-yellow-50 dark:bg-gray-700  transition-transform duration-200 hover:scale-105 active:scale-95 focus:outline-none focus-visible:ring-4 focus-visible:ring-teal-400 focus-visible:ring-offset-2 border-l-4 border-yellow-400 rounded-lg shadow px-6 py-4 mb-0 flex items-start gap-4 cursor-pointer focus:outline-none focus:ring-2 focus:ring-yellow-400 hover:scale-[1.03] hover:shadow-2xl transition-all group">
               <span class="flex-shrink-0 mt-1 text-yellow-500">
                 <!-- Adjustments Icon -->
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-7 w-7" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v12m6-6H6"/></svg>
               </span>
               <div class="flex-1">
-                <span class="font-semibold text-blue-900">Hybrid and advanced search techniques</span>
+                <span class="font-semibold text-blue-900 dark:text-white">Hybrid and advanced search techniques</span>
                 <span class="ml-auto flex items-center justify-center">
                   <svg class="chevron h-7 w-7 text-yellow-400 transition-transform duration-300 group-aria-expanded:rotate-180" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
                 </span>
-                <span id="about-blurb-5" class="block italic text-blue-700 text-base mt-3 hidden">Explore hybrid approaches that combine traditional and vector search, and learn advanced methods for boosting relevance.</span>
+                <span id="about-blurb-5" class="block italic text-blue-700 dark:text-gray-200 text-base mt-3 hidden">Explore hybrid approaches that combine traditional and vector search, and learn advanced methods for boosting relevance.</span>
               </div>
             </li>
             <!-- Card 6: Chart Bar -->
-            <li tabindex="0" role="button" aria-expanded="false" aria-controls="about-blurb-6" onclick="toggleBlurb('about-blurb-6', this)" onkeydown="if(event.key==='Enter'||event.key===' '){toggleBlurb('about-blurb-6', this)}" class="relative bg- transition-transform duration-200 hover:scale-105 active:scale-95 focus:outline-none focus-visible:ring-4 focus-visible:ring-teal-400 focus-visible:ring-offset-2pink-50 border-l-4 border-pink-400 rounded-lg shadow px-6 py-4 mb-0 flex items-start gap-4 cursor-pointer focus:outline-none focus:ring-2 focus:ring-pink-400 hover:scale-[1.03] hover:shadow-2xl transition-all group">
+            <li tabindex="0" role="button" aria-expanded="false" aria-controls="about-blurb-6" onclick="toggleBlurb('about-blurb-6', this)" onkeydown="if(event.key==='Enter'||event.key===' '){toggleBlurb('about-blurb-6', this)}" class="relative bg-pink-50 dark:bg-gray-700  transition-transform duration-200 hover:scale-105 active:scale-95 focus:outline-none focus-visible:ring-4 focus-visible:ring-teal-400 focus-visible:ring-offset-2 border-l-4 border-pink-400 rounded-lg shadow px-6 py-4 mb-0 flex items-start gap-4 cursor-pointer focus:outline-none focus:ring-2 focus:ring-pink-400 hover:scale-[1.03] hover:shadow-2xl transition-all group">
               <span class="flex-shrink-0 mt-1 text-pink-500">
                 <!-- Chart Bar Icon -->
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-7 w-7" fill="none" viewBox="0 0 24 24" stroke="currentColor"><rect x="3" y="13" width="4" height="8"/><rect x="9" y="9" width="4" height="12"/><rect x="15" y="5" width="4" height="16"/></svg>
               </span>
               <div class="flex-1">
-                <span class="font-semibold text-blue-900">Real-world use cases and practical tips</span>
+                <span class="font-semibold text-blue-900 dark:text-white">Real-world use cases and practical tips</span>
                 <span class="ml-auto flex items-center justify-center">
                   <svg class="chevron h-7 w-7 text-pink-400 transition-transform duration-300 group-aria-expanded:rotate-180" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
                 </span>
-                <span id="about-blurb-6" class="block italic text-blue-700 text-base mt-3 hidden">See how companies use vector search in production, and get actionable tips to avoid common pitfalls.</span>
+                <span id="about-blurb-6" class="block italic text-blue-700 dark:text-gray-200 text-base mt-3 hidden">See how companies use vector search in production, and get actionable tips to avoid common pitfalls.</span>
               </div>
             </li>
           </ul>


### PR DESCRIPTION
## Summary
- lighten card backgrounds and text colors for dark mode mobile

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845d307b878832b8fe89860330297eb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved dark mode support for the "About the Book" section, ensuring list items and text display appropriate colors and contrast when dark mode is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->